### PR TITLE
test: add end-to-end tests for the booking API

### DIFF
--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/ApiClient.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/ApiClient.java
@@ -1,0 +1,9 @@
+package org.denysr.learning.office_booking.e2e;
+
+/**
+ * Marks a client of one part of the API. Implementations take the base URL of the running
+ * application as their only constructor argument, which is what lets {@link ApplicationUnderTest}
+ * build them from its registry and inject them into tests.
+ */
+interface ApiClient {
+}

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/ApiResponse.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/ApiResponse.java
@@ -18,9 +18,14 @@ record ApiResponse(int status, String body) {
         }
     }
 
-    /** Id returned by the create and change endpoints. */
+    /** Id returned by the user create and change endpoints. */
     int userId() {
         return json().path("userId").asInt();
+    }
+
+    /** Id returned by the booking create endpoint. */
+    int bookingId() {
+        return json().path("bookingId").asInt();
     }
 
     /** Message of an {@code ErrorResponse}. */

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/ApplicationUnderTest.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/ApplicationUnderTest.java
@@ -36,8 +36,8 @@ final class ApplicationUnderTest implements BeforeAllCallback, ParameterResolver
     private static final Namespace NAMESPACE = Namespace.create(ApplicationUnderTest.class);
 
     /** The injectable API clients, each built from the base URL of the running application. */
-    private static final Map<Class<?>, Function<String, Object>> CLIENTS =
-            Map.<Class<?>, Function<String, Object>>of(
+    private static final Map<Class<? extends ApiClient>, Function<String, ApiClient>> CLIENTS =
+            Map.<Class<? extends ApiClient>, Function<String, ApiClient>>of(
                     UserApiClient.class, UserApiClient::new,
                     BookingApiClient.class, BookingApiClient::new
             );
@@ -77,7 +77,7 @@ final class ApplicationUnderTest implements BeforeAllCallback, ParameterResolver
 
         private final GenericContainer<?> container;
         private final String baseUrl;
-        private final Map<Class<?>, Object> clients = new ConcurrentHashMap<>();
+        private final Map<Class<?>, ApiClient> clients = new ConcurrentHashMap<>();
 
         private RunningApplication() {
             container = createContainer();
@@ -89,7 +89,7 @@ final class ApplicationUnderTest implements BeforeAllCallback, ParameterResolver
         }
 
         /** One client per type, created on first use and shared by every test that asks for it. */
-        private Object client(Class<?> type) {
+        private ApiClient client(Class<?> type) {
             return clients.computeIfAbsent(type, key -> CLIENTS.get(key).apply(baseUrl));
         }
 

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/ApplicationUnderTest.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/ApplicationUnderTest.java
@@ -38,7 +38,8 @@ final class ApplicationUnderTest implements BeforeAllCallback, ParameterResolver
     /** The injectable API clients, each built from the base URL of the running application. */
     private static final Map<Class<?>, Function<String, Object>> CLIENTS =
             Map.<Class<?>, Function<String, Object>>of(
-                    UserApiClient.class, UserApiClient::new
+                    UserApiClient.class, UserApiClient::new,
+                    BookingApiClient.class, BookingApiClient::new
             );
 
     /** Fail on startup problems here rather than on the first test that touches the API. */

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/BookingApiClient.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/BookingApiClient.java
@@ -1,0 +1,25 @@
+package org.denysr.learning.office_booking.e2e;
+
+import java.time.LocalDate;
+
+/** Client for the {@code /office} API. */
+final class BookingApiClient {
+    private final HttpCalls http;
+
+    BookingApiClient(String baseUrl) {
+        this.http = new HttpCalls(baseUrl);
+    }
+
+    ApiResponse createBooking(BookingPayload booking) {
+        return http.send(http.request("/office/booking").POST(HttpCalls.jsonBody(booking)));
+    }
+
+    /** Bookings of the whole business week that the given day falls into. */
+    ApiResponse getBookingsForWeekOf(LocalDate businessDay) {
+        return http.send(http.request("/office/bookings/" + businessDay).GET());
+    }
+
+    ApiResponse deleteBooking(int bookingId) {
+        return http.send(http.request("/office/booking/" + bookingId).DELETE());
+    }
+}

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/BookingApiClient.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/BookingApiClient.java
@@ -3,7 +3,7 @@ package org.denysr.learning.office_booking.e2e;
 import java.time.LocalDate;
 
 /** Client for the {@code /office} API. */
-final class BookingApiClient {
+final class BookingApiClient implements ApiClient {
     private final HttpCalls http;
 
     BookingApiClient(String baseUrl) {

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/BookingApiE2eTest.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/BookingApiE2eTest.java
@@ -1,0 +1,173 @@
+package org.denysr.learning.office_booking.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * End-to-end coverage of the basic booking path against the application running in a container.
+ * <p>
+ * Listing bookings returns everything booked in that business week by anyone, so each test claims a
+ * week of its own rather than filtering other tests out of a shared one.
+ */
+@ExtendWith(ApplicationUnderTest.class)
+class BookingApiE2eTest {
+    /** A Monday, far enough out that no other test data lands in these weeks. */
+    private static final LocalDate FIRST_WEEK_MONDAY = LocalDate.of(2030, 1, 7);
+    private static final AtomicInteger WEEK_COUNTER = new AtomicInteger();
+    private static final AtomicInteger EMAIL_COUNTER = new AtomicInteger();
+
+    private final BookingApiClient bookings;
+    private final UserApiClient users;
+
+    BookingApiE2eTest(BookingApiClient bookings, UserApiClient users) {
+        this.bookings = bookings;
+        this.users = users;
+    }
+
+    @Test
+    @DisplayName("A booked office shows up in the bookings of its week")
+    void bookedOfficeIsListedForItsWeek() {
+        final int userId = registerUser("Lena", "Novak");
+        final LocalDate monday = ownWeek();
+        final LocalDate friday = monday.with(DayOfWeek.FRIDAY);
+
+        final ApiResponse created = bookings.createBooking(BookingPayload.of(userId, monday, friday));
+        assertThat(created.status()).as("create: %s", created).isEqualTo(201);
+
+        final int bookingId = created.bookingId();
+        assertThat(bookingId).isPositive();
+
+        final ApiResponse forWeek = bookings.getBookingsForWeekOf(monday);
+        assertThat(forWeek.status()).as("list: %s", forWeek).isEqualTo(200);
+
+        final JsonNode listed = findById(forWeek.json(), bookingId);
+        assertThat(listed).as("booking %d in %s", bookingId, forWeek.body()).isNotNull();
+        assertThat(listed.path("userName").asText()).isEqualTo("Lena Novak");
+        assertThat(listed.path("startDate").asText()).isEqualTo(monday.toString());
+        assertThat(listed.path("endDate").asText()).isEqualTo(friday.toString());
+    }
+
+    @Test
+    @DisplayName("A deleted booking disappears from the bookings of its week")
+    void deletedBookingIsNotListed() {
+        final int userId = registerUser("Marco", "Rossi");
+        final LocalDate monday = ownWeek();
+        final int bookingId = book(userId, monday, monday.with(DayOfWeek.FRIDAY));
+
+        final ApiResponse deleted = bookings.deleteBooking(bookingId);
+        assertThat(deleted.status()).as("delete: %s", deleted).isEqualTo(200);
+
+        final ApiResponse forWeek = bookings.getBookingsForWeekOf(monday);
+        assertThat(forWeek.status()).isEqualTo(200);
+        assertThat(findById(forWeek.json(), bookingId))
+                .as("booking %d should be gone", bookingId)
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("A week with nothing booked lists no bookings")
+    void emptyWeekListsNothing() {
+        final ApiResponse forWeek = bookings.getBookingsForWeekOf(ownWeek());
+
+        assertThat(forWeek.status()).as("%s", forWeek).isEqualTo(200);
+        assertThat(forWeek.json()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Booking a range without a business day is rejected")
+    void weekendOnlyBookingIsRejected() {
+        final int userId = registerUser("Ida", "Berg");
+        final LocalDate saturday = ownWeek().plusDays(5);
+
+        final ApiResponse response =
+                bookings.createBooking(BookingPayload.of(userId, saturday, saturday.plusDays(1)));
+
+        assertThat(response.status()).as("%s", response).isEqualTo(422);
+        assertThat(response.error()).isEqualTo("There should be at least one business day in the range");
+    }
+
+    @Test
+    @DisplayName("Booking a range that ends before it starts is rejected")
+    void invertedRangeIsRejected() {
+        final int userId = registerUser("Petr", "Novy");
+        final LocalDate monday = ownWeek();
+
+        final ApiResponse response =
+                bookings.createBooking(BookingPayload.of(userId, monday.with(DayOfWeek.FRIDAY), monday));
+
+        assertThat(response.status()).as("%s", response).isEqualTo(422);
+        assertThat(response.error()).isEqualTo("End date should be after start date");
+    }
+
+    @Test
+    @DisplayName("Deleting a booking with a non-positive id is rejected")
+    void nonPositiveBookingIdIsRejected() {
+        final ApiResponse response = bookings.deleteBooking(0);
+
+        assertThat(response.status()).as("%s", response).isEqualTo(406);
+        assertThat(response.error()).isEqualTo("Booking id should be above 0.");
+    }
+
+    /*
+     * As with the user API, the paths below are documented behaviour the application does not
+     * implement yet. Enable them together with the fix rather than weakening the expectations.
+     */
+
+    @Test
+    @Disabled("Known defect: mapping the missing user blows up, so the endpoint answers 500")
+    @DisplayName("Booking for an unknown user reports a client error")
+    void bookingForUnknownUserIsRejected() {
+        final LocalDate monday = ownWeek();
+
+        final ApiResponse response = bookings.createBooking(
+                BookingPayload.of(Integer.MAX_VALUE, monday, monday.with(DayOfWeek.FRIDAY)));
+
+        assertThat(response.status()).as("%s", response).isBetween(400, 499);
+    }
+
+    @Test
+    @Disabled("Known defect: deleteById is a no-op for unknown ids, so the endpoint answers 200")
+    @DisplayName("Deleting an unknown booking reports not found")
+    void deletingUnknownBookingReportsNotFound() {
+        final ApiResponse response = bookings.deleteBooking(Integer.MAX_VALUE);
+
+        assertThat(response.status()).as("%s", response).isEqualTo(404);
+    }
+
+    private int registerUser(String firstName, String secondName) {
+        final String email = "e2e.booker." + EMAIL_COUNTER.incrementAndGet() + "@example.com";
+        final ApiResponse created = users.createUser(new UserPayload(email, firstName, secondName));
+        assertThat(created.status()).as("create user: %s", created).isEqualTo(201);
+        return created.userId();
+    }
+
+    private int book(int userId, LocalDate startDate, LocalDate endDate) {
+        final ApiResponse created = bookings.createBooking(BookingPayload.of(userId, startDate, endDate));
+        assertThat(created.status()).as("create booking: %s", created).isEqualTo(201);
+        return created.bookingId();
+    }
+
+    /** A business week no other test touches, so listings only ever show this test's bookings. */
+    private static LocalDate ownWeek() {
+        return FIRST_WEEK_MONDAY.plusWeeks(WEEK_COUNTER.getAndIncrement());
+    }
+
+    private static JsonNode findById(JsonNode bookings, int bookingId) {
+        for (JsonNode booking : bookings) {
+            if (booking.path("bookingId").asInt() == bookingId) {
+                return booking;
+            }
+        }
+        return null;
+    }
+}

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/BookingPayload.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/BookingPayload.java
@@ -1,0 +1,14 @@
+package org.denysr.learning.office_booking.e2e;
+
+import java.time.LocalDate;
+
+/**
+ * Request body of the booking endpoint. Dates are strings so that the tests send the wire format
+ * verbatim rather than whatever a date module would produce.
+ */
+record BookingPayload(int userId, String startDate, String endDate) {
+
+    static BookingPayload of(int userId, LocalDate startDate, LocalDate endDate) {
+        return new BookingPayload(userId, startDate.toString(), endDate.toString());
+    }
+}

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/HttpCalls.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/HttpCalls.java
@@ -1,0 +1,55 @@
+package org.denysr.learning.office_booking.e2e;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublisher;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** Plain HTTP plumbing shared by the API clients, so that nothing but the contract is tested. */
+final class HttpCalls {
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+    private final String baseUrl;
+
+    HttpCalls(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    HttpRequest.Builder request(String path) {
+        return HttpRequest.newBuilder(URI.create(baseUrl + path))
+                .timeout(Duration.ofSeconds(30))
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json");
+    }
+
+    static BodyPublisher jsonBody(Object payload) {
+        try {
+            return BodyPublishers.ofString(JSON.writeValueAsString(payload));
+        } catch (JsonProcessingException e) {
+            throw new UncheckedIOException("Cannot serialise " + payload, e);
+        }
+    }
+
+    ApiResponse send(HttpRequest.Builder request) {
+        try {
+            final var response = httpClient.send(request.build(), BodyHandlers.ofString());
+            return new ApiResponse(response.statusCode(), response.body());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Request to the application under test failed", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while calling the application under test", e);
+        }
+    }
+}

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/UserApiClient.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/UserApiClient.java
@@ -1,7 +1,7 @@
 package org.denysr.learning.office_booking.e2e;
 
 /** Client for the {@code /users} API. */
-final class UserApiClient {
+final class UserApiClient implements ApiClient {
     private final HttpCalls http;
 
     UserApiClient(String baseUrl) {

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/UserApiClient.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/UserApiClient.java
@@ -1,75 +1,30 @@
 package org.denysr.learning.office_booking.e2e;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublisher;
-import java.net.http.HttpRequest.BodyPublishers;
-import java.net.http.HttpResponse.BodyHandlers;
-import java.time.Duration;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-/** Client for the {@code /users} API, speaking plain HTTP so that nothing but the contract is tested. */
+/** Client for the {@code /users} API. */
 final class UserApiClient {
-    private static final ObjectMapper JSON = new ObjectMapper();
-
-    private final HttpClient httpClient = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(10))
-            .build();
-    private final String baseUrl;
+    private final HttpCalls http;
 
     UserApiClient(String baseUrl) {
-        this.baseUrl = baseUrl;
+        this.http = new HttpCalls(baseUrl);
     }
 
     ApiResponse createUser(UserPayload user) {
-        return send(request("/users/user").POST(jsonBody(user)));
+        return http.send(http.request("/users/user").POST(HttpCalls.jsonBody(user)));
     }
 
     ApiResponse changeUser(int userId, UserPayload user) {
-        return send(request("/users/user/" + userId).PUT(jsonBody(user)));
+        return http.send(http.request("/users/user/" + userId).PUT(HttpCalls.jsonBody(user)));
     }
 
     ApiResponse getUser(int userId) {
-        return send(request("/users/user/" + userId).GET());
+        return http.send(http.request("/users/user/" + userId).GET());
     }
 
     ApiResponse getAllUsers() {
-        return send(request("/users/users").GET());
+        return http.send(http.request("/users/users").GET());
     }
 
     ApiResponse deleteUser(int userId) {
-        return send(request("/users/user/" + userId).DELETE());
-    }
-
-    private HttpRequest.Builder request(String path) {
-        return HttpRequest.newBuilder(URI.create(baseUrl + path))
-                .timeout(Duration.ofSeconds(30))
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/json");
-    }
-
-    private static BodyPublisher jsonBody(Object payload) {
-        try {
-            return BodyPublishers.ofString(JSON.writeValueAsString(payload));
-        } catch (JsonProcessingException e) {
-            throw new UncheckedIOException("Cannot serialise " + payload, e);
-        }
-    }
-
-    private ApiResponse send(HttpRequest.Builder request) {
-        try {
-            final var response = httpClient.send(request.build(), BodyHandlers.ofString());
-            return new ApiResponse(response.statusCode(), response.body());
-        } catch (IOException e) {
-            throw new UncheckedIOException("Request to the application under test failed", e);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted while calling the application under test", e);
-        }
+        return http.send(http.request("/users/user/" + userId).DELETE());
     }
 }

--- a/src/main/java/org/denysr/learning/office_booking/config/ModelMapperConfig.java
+++ b/src/main/java/org/denysr/learning/office_booking/config/ModelMapperConfig.java
@@ -101,7 +101,9 @@ public class ModelMapperConfig {
         bookingtoJpaMap.setProvider(request -> {
             Booking source = (Booking) request.getSource();
             BookingJpaDto bookingJpaDto = new BookingJpaDto();
-            bookingJpaDto.setBookingId(source.bookingId().bookingId());
+            if (source.hasId()) {
+                bookingJpaDto.setBookingId(source.bookingId().bookingId());
+            }
             bookingJpaDto.setStartDate(source.bookingDateRange().getStartDate());
             bookingJpaDto.setEndDate(source.bookingDateRange().getEndDate());
             bookingJpaDto.setUserDto(modelMapper.map(source.user(), UserJpaDto.class));

--- a/src/test/java/org/denysr/learning/office_booking/infrastructure/jpa/booking/BookingDtoMappingTest.java
+++ b/src/test/java/org/denysr/learning/office_booking/infrastructure/jpa/booking/BookingDtoMappingTest.java
@@ -52,6 +52,24 @@ public class BookingDtoMappingTest {
     }
 
     @Test
+    void shouldConvertNotYetSavedDomainBookingToJpaDto() {
+        Booking booking = Booking.builder()
+                .withUser(USER)
+                .withBookingDateRange(new BookingDateRange(START_DATE, END_DATE))
+                .build();
+
+        BookingJpaDto bookingJpaDto = modelMapper.map(booking, BookingJpaDto.class);
+
+        assertAll(
+                // The id is a primitive, so 0 is what Hibernate reads as "not saved yet".
+                () -> assertEquals(0, bookingJpaDto.getBookingId()),
+                () -> assertEquals(USER_DTO, bookingJpaDto.getUserDto()),
+                () -> assertEquals(START_DATE, bookingJpaDto.getStartDate()),
+                () -> assertEquals(END_DATE, bookingJpaDto.getEndDate())
+        );
+    }
+
+    @Test
     void shouldConvertJpaDtoBookingToDomainModel() {
         BookingJpaDto bookingJpaDto = new BookingJpaDto(BOOKING_ID, USER_DTO, START_DATE, END_DATE);
 


### PR DESCRIPTION
## What

Adds end-to-end coverage of the basic office booking path, reusing the container and extension introduced for the user API in #53.

Six tests in `BookingApiE2eTest`:

- book Mon–Fri → `201`, and the booking appears in that week's listing with the right user name and dates
- delete the booking → `200`, and it disappears from the week
- a week with nothing booked lists nothing
- a range with no business day (Sat–Sun) → `422`
- a range that ends before it starts → `422`
- delete with a non-positive id → `406`

`GET /office/bookings/{day}` returns everything **anyone** booked in that business week, so tests would otherwise see each other's data. Each test claims its own week off a counter starting at `2030-01-07` rather than filtering a shared one.

## Production fix: creating a booking was impossible

`POST /office/booking` returned `500` for **every** request. The `Booking` → `BookingJpaDto` provider in `ModelMapperConfig` read `source.bookingId().bookingId()` unconditionally, but `BookingManagement.insertBooking` builds `new Booking(null, user, range)` — so it threw on every insert.

Fixed with the same guard the `User` mapping 40 lines above already uses:

```java
if (source.hasId()) {
    bookingJpaDto.setBookingId(source.bookingId().bookingId());
}
```

Covered by a new `shouldConvertNotYetSavedDomainBookingToJpaDto` case in `BookingDtoMappingTest`, verified to fail without the fix and pass with it. (`BookingJpaDto.bookingId` is a primitive `int`, so an unsaved booking maps to `0` — Hibernate's unsaved-value for a generated primitive id.)

## Test infrastructure

- `HttpCalls` — the HTTP plumbing moves out of `UserApiClient` so both clients share it instead of duplicating it.
- `ApiClient` — a marker interface, so the registry is `Map<Class<? extends ApiClient>, Function<String, ApiClient>>` instead of `Class<?>`/`Object`. Registering a non-client is now a compile error.
- `BookingApiClient` slots in via one registry entry, as designed. `BookingApiE2eTest` takes both `BookingApiClient` and `UserApiClient` in its constructor — it needs users to book for — and both resolve against the same container.

## Two more defects found

Present as `@Disabled` tests stating the expected behaviour, matching the convention from #53:

| Request | Actual | Expected |
|---|---|---|
| `POST /office/booking` for an unknown user | 500 | 4xx |
| `DELETE /office/booking/{unknown}` | 200 | 404 |

Both share root causes with the already-documented user-API defects: `modelMapper.map(null, …)` throwing instead of the repository raising `EntityNotFoundException`, and Spring Data's `deleteById` being a no-op for missing ids.

## Testing

Full suite run locally against Podman: **23 tests, 17 passing, 6 skipped, 0 failures**, one container shared across both test classes, no containers left behind. `./gradlew build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)