### PR TITLE
fix: report unknown users and taken emails on the user API

### DIFF
--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/UserApiE2eTest.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/UserApiE2eTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -165,14 +164,7 @@ class UserApiE2eTest {
         assertThat(response.error()).isEqualTo("User id should be above 0.");
     }
 
-    /*
-     * The tests below describe how the API is documented to behave on the "unknown user" and
-     * "email already taken" paths. They are disabled because the application does not behave that
-     * way yet - enable them together with the fix rather than weakening the expectations.
-     */
-
     @Test
-    @Disabled("Known defect: deleteById is a no-op for unknown ids, so the endpoint answers 200")
     @DisplayName("Unregistering an unknown user reports not found")
     void deletingUnknownUserReportsNotFound() {
         final ApiResponse response = api.deleteUser(Integer.MAX_VALUE);
@@ -181,7 +173,6 @@ class UserApiE2eTest {
     }
 
     @Test
-    @Disabled("Known defect: mapping the missing row blows up, so the endpoint answers 500")
     @DisplayName("Reading an unknown user reports not found")
     void readingUnknownUserReportsNotFound() {
         final ApiResponse response = api.getUser(Integer.MAX_VALUE);
@@ -190,7 +181,6 @@ class UserApiE2eTest {
     }
 
     @Test
-    @Disabled("Known defect: the endpoint answers 500 instead of reporting the unknown id")
     @DisplayName("Changing an unknown user reports not found")
     void changingUnknownUserReportsNotFound() {
         final ApiResponse response =
@@ -200,7 +190,6 @@ class UserApiE2eTest {
     }
 
     @Test
-    @Disabled("Known defect: the unique email constraint surfaces as 500 instead of a client error")
     @DisplayName("Registering an email that is already taken is rejected")
     void duplicateEmailIsRejected() {
         final String email = uniqueEmail();

--- a/src/main/java/org/denysr/learning/office_booking/controllers/UserController.java
+++ b/src/main/java/org/denysr/learning/office_booking/controllers/UserController.java
@@ -13,6 +13,7 @@ import org.denysr.learning.office_booking.domain.user.User;
 import org.denysr.learning.office_booking.domain.user.User.UserBuilder;
 import org.denysr.learning.office_booking.domain.user.UserId;
 import org.denysr.learning.office_booking.domain.user.UserManagement;
+import org.denysr.learning.office_booking.domain.user.exceptions.EmailAlreadyTakenException;
 import org.denysr.learning.office_booking.domain.validation.EntityNotFoundException;
 import org.denysr.learning.office_booking.domain.validation.IllegalValueException;
 import org.denysr.learning.office_booking.infrastructure.rest.ErrorResponse;
@@ -44,6 +45,8 @@ final public class UserController {
                     description = "Invalid parameter(s) supplied",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
             ),
+            @ApiResponse(responseCode = "409", description = "Email is already taken by another user",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "Unknown server error",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     })
@@ -59,6 +62,8 @@ final public class UserController {
         } catch (MappingException e) {
             return ResponseEntity.status(HttpStatus.UNPROCESSABLE_CONTENT)
                     .body(new ErrorResponse(e.getCause().getMessage()));
+        } catch (EmailAlreadyTakenException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorResponse(e.getMessage()));
         } catch (Exception e) {
             log.error("Error processing user creation", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ErrorResponse(""));
@@ -75,6 +80,8 @@ final public class UserController {
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
             ),
             @ApiResponse(responseCode = "404", description = "User with mentioned id not found",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Email is already taken by another user",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "Unknown server error",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
@@ -97,6 +104,8 @@ final public class UserController {
                     .body(new ErrorResponse(e.getCause().getMessage()));
         } catch (EntityNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponse(e.getMessage()));
+        } catch (EmailAlreadyTakenException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorResponse(e.getMessage()));
         } catch (Exception e) {
             log.error("Error changing user", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ErrorResponse(""));

--- a/src/main/java/org/denysr/learning/office_booking/domain/user/exceptions/EmailAlreadyTakenException.java
+++ b/src/main/java/org/denysr/learning/office_booking/domain/user/exceptions/EmailAlreadyTakenException.java
@@ -1,0 +1,12 @@
+package org.denysr.learning.office_booking.domain.user.exceptions;
+
+/** Thrown when a user is stored under an email address another user already uses. */
+public class EmailAlreadyTakenException extends RuntimeException {
+    public EmailAlreadyTakenException(String message) {
+        super(message);
+    }
+
+    public EmailAlreadyTakenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/denysr/learning/office_booking/infrastructure/jpa/user/UserRepositoryJpaImpl.java
+++ b/src/main/java/org/denysr/learning/office_booking/infrastructure/jpa/user/UserRepositoryJpaImpl.java
@@ -4,10 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.denysr.learning.office_booking.domain.user.User;
 import org.denysr.learning.office_booking.domain.user.UserId;
 import org.denysr.learning.office_booking.domain.user.UserRepository;
+import org.denysr.learning.office_booking.domain.user.exceptions.EmailAlreadyTakenException;
 import org.denysr.learning.office_booking.domain.validation.EntityNotFoundException;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
-import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -20,7 +21,11 @@ public class UserRepositoryJpaImpl implements UserRepository {
 
     @Override
     public User findUserById(UserId userId) throws EntityNotFoundException {
-        return modelMapper.map(jpaUserRepository.findByUserId(userId.userId()), User.class);
+        final UserJpaDto userDto = jpaUserRepository.findByUserId(userId.userId());
+        if (userDto == null) {
+            throw new EntityNotFoundException(notFoundMessage(userId));
+        }
+        return modelMapper.map(userDto, User.class);
     }
 
     @Override
@@ -31,20 +36,42 @@ public class UserRepositoryJpaImpl implements UserRepository {
         );
     }
 
+    /**
+     * Saving a user with an id that no longer exists would silently insert a new row under a fresh
+     * id, so an update of an unknown user is reported as such instead.
+     */
     @Override
     public UserId saveUser(User user) throws EntityNotFoundException {
-        final int userId = jpaUserRepository
-                .save(modelMapper.map(user, UserJpaDto.class))
-                .getUserId();
+        if (user.userId() != null) {
+            requireExisting(user.userId());
+        }
+        final int userId;
+        try {
+            userId = jpaUserRepository
+                    .save(modelMapper.map(user, UserJpaDto.class))
+                    .getUserId();
+        } catch (DataIntegrityViolationException e) {
+            // The only constraint on the table is the unique email index.
+            throw new EmailAlreadyTakenException(
+                    "Email " + user.userEmail().email() + " is already taken", e);
+        }
         return new UserId(userId);
     }
 
+    /** {@code deleteById} is a no-op for unknown ids, so the row has to be looked up first. */
     @Override
     public void deleteUser(UserId userId) throws EntityNotFoundException {
-        try {
-            jpaUserRepository.deleteById(userId.userId());
-        } catch (EmptyResultDataAccessException e) {
-            throw new EntityNotFoundException("User with the mentioned id not found", e);
+        requireExisting(userId);
+        jpaUserRepository.deleteById(userId.userId());
+    }
+
+    private void requireExisting(UserId userId) throws EntityNotFoundException {
+        if (!jpaUserRepository.existsById(userId.userId())) {
+            throw new EntityNotFoundException(notFoundMessage(userId));
         }
+    }
+
+    private static String notFoundMessage(UserId userId) {
+        return "User with id " + userId.userId() + " not found";
     }
 }


### PR DESCRIPTION
Fixes the four defects the user e2e tests documented in #53 and enables the `@Disabled` tests that covered them.

## The defects

| Request | Was | Now |
| --- | --- | --- |
| `GET /users/user/{unknown}` | 500 | 404 |
| `DELETE /users/user/{unknown}` | 200 | 404 |
| `PUT /users/user/{unknown}` | 500 | 404 |
| `POST /users/user` with a taken email | 500 | 409 |

- **Reading** — `findByUserId` returns `null` for an unknown id and mapping that blew up. The repository reports it as missing instead.
- **Deleting** — `deleteById` is a silent no-op for unknown ids, so the `EmptyResultDataAccessException` the code caught never arrives. The row is looked up before deleting.
- **Changing** — saving a user whose id no longer exists inserts a *new* row under a fresh id, which then trips the id mismatch check. An unknown id is rejected up front.
- **Duplicate email** — the unique email index surfaced as `DataIntegrityViolationException`. It is translated to a new `EmailAlreadyTakenException` and answered with 409 Conflict, documented in the OpenAPI annotations.

The first three raise `EntityNotFoundException`, which both endpoints already map to 404.

## Testing

- `./gradlew test` green
- `./gradlew e2eTest` green, with all 14 `UserApiE2eTest` tests now running

## Out of scope

The two `@Disabled` tests in `BookingApiE2eTest` stay disabled: booking deletion has the same `deleteById` no-op bug, and `createBooking` only catches `IllegalValueException`, so a booking for an unknown user still answers 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)