### PR TITLE
fix: report unknown users and bookings on the booking API

### DIFF
--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/BookingApiE2eTest.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/BookingApiE2eTest.java
@@ -6,7 +6,6 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -118,13 +117,7 @@ class BookingApiE2eTest {
         assertThat(response.error()).isEqualTo("Booking id should be above 0.");
     }
 
-    /*
-     * As with the user API, the paths below are documented behaviour the application does not
-     * implement yet. Enable them together with the fix rather than weakening the expectations.
-     */
-
     @Test
-    @Disabled("Known defect: mapping the missing user blows up, so the endpoint answers 500")
     @DisplayName("Booking for an unknown user reports a client error")
     void bookingForUnknownUserIsRejected() {
         final LocalDate monday = ownWeek();
@@ -136,7 +129,6 @@ class BookingApiE2eTest {
     }
 
     @Test
-    @Disabled("Known defect: deleteById is a no-op for unknown ids, so the endpoint answers 200")
     @DisplayName("Deleting an unknown booking reports not found")
     void deletingUnknownBookingReportsNotFound() {
         final ApiResponse response = bookings.deleteBooking(Integer.MAX_VALUE);

--- a/src/main/java/org/denysr/learning/office_booking/controllers/OfficeBookingController.java
+++ b/src/main/java/org/denysr/learning/office_booking/controllers/OfficeBookingController.java
@@ -52,6 +52,8 @@ final public class OfficeBookingController {
                     description = "Invalid parameter(s) supplied",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
             ),
+            @ApiResponse(responseCode = "404", description = "User with mentioned id not found",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "Unknown server error",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     })
@@ -68,6 +70,8 @@ final public class OfficeBookingController {
             return ResponseEntity.status(HttpStatus.CREATED).body(bookingId);
         } catch (IllegalValueException e) {
             return ResponseEntity.status(HttpStatus.UNPROCESSABLE_CONTENT).body(new ErrorResponse(e.getMessage()));
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponse(e.getMessage()));
         } catch (Exception e) {
             log.error("Error processing booking creation", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ErrorResponse(""));

--- a/src/main/java/org/denysr/learning/office_booking/domain/booking/BookingManagement.java
+++ b/src/main/java/org/denysr/learning/office_booking/domain/booking/BookingManagement.java
@@ -6,7 +6,6 @@ import org.denysr.learning.office_booking.domain.user.User;
 import org.denysr.learning.office_booking.domain.user.UserId;
 import org.denysr.learning.office_booking.domain.user.UserRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.util.Assert;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,7 +18,6 @@ final public class BookingManagement {
 
     public BookingId insertBooking(UserId userId, BookingDateRange bookingDateRange) {
         User user = userRepository.findUserById(userId);
-        Assert.notNull(user, "User with mentioned id doesn't exist");
         // Additional validation could be provided here, like check for timeframe intersections for particular user etc
         // Should be implemented after communicating to domain expert/product owner.
         Booking booking = new Booking(null, user, bookingDateRange);

--- a/src/main/java/org/denysr/learning/office_booking/infrastructure/jpa/booking/BookingRepositoryJpaImpl.java
+++ b/src/main/java/org/denysr/learning/office_booking/infrastructure/jpa/booking/BookingRepositoryJpaImpl.java
@@ -8,7 +8,6 @@ import org.denysr.learning.office_booking.domain.booking.BusinessWeek;
 import org.denysr.learning.office_booking.domain.validation.EntityNotFoundException;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.TypeToken;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -35,12 +34,12 @@ public class BookingRepositoryJpaImpl implements BookingRepository {
                 ), new TypeToken<List<Booking>>() {}.getType());
     }
 
+    /** {@code deleteById} is a no-op for unknown ids, so the row has to be looked up first. */
     @Override
     public void deleteBooking(BookingId bookingId) throws EntityNotFoundException {
-        try {
-            jpaBookingRepository.deleteById(bookingId.bookingId());
-        } catch (EmptyResultDataAccessException e) {
-            throw new EntityNotFoundException("Booking with the mentioned id not found", e);
+        if (!jpaBookingRepository.existsById(bookingId.bookingId())) {
+            throw new EntityNotFoundException("Booking with id " + bookingId.bookingId() + " not found");
         }
+        jpaBookingRepository.deleteById(bookingId.bookingId());
     }
 }


### PR DESCRIPTION
Fixes the two defects the booking e2e tests documented in #54 and enables the `@Disabled` tests that covered them, mirroring the user API fix in #55.

## The defects

| Request | Was | Now |
| --- | --- | --- |
| `POST /office/booking` for an unknown user | 500 | 404 |
| `DELETE /office/booking/{unknown}` | 200 | 404 |

- **Booking for an unknown user** — `UserRepositoryJpaImpl.findUserById` now throws `EntityNotFoundException` instead of returning `null` (fixed in #55), which made the `Assert.notNull` check in `BookingManagement.insertBooking` dead code and left the exception falling through to `OfficeBookingController`'s generic 500 handler. Removed the now-unreachable check and added a 404 mapping for `EntityNotFoundException`, documented in the OpenAPI annotations.
- **Deleting an unknown booking** — `deleteById` is a silent no-op for unknown ids, the same bug fixed for user deletion in #55. The row is looked up before deleting.

## Testing

- `./gradlew test` green
- `./gradlew e2eTest` green: all 22 e2e tests pass, none skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)