### PR TITLE
docs: document the e2e tests in the project context

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -5,13 +5,15 @@ A Spring Boot REST API application for booking office spots with user management
 
 ## Tech Stack
 - **Framework**: Spring Boot 4.1.0
-- **Java Version**: Java 25
-- **Build Tool**: Gradle 9
+- **Java Version**: Java 25 (Gradle toolchain)
+- **Build Tool**: Gradle 9, dependency versions in the version catalog `gradle/libs.versions.toml`
 - **Database**: H2 (in-memory)
 - **ORM**: Spring Data JPA
 - **Validation**: Hibernate Validator, CommonsValidator
 - **Documentation**: Springdoc OpenAPI UI (Swagger)
 - **Mapping**: ModelMapper
+- **Boilerplate**: Lombok (compile-only + annotation processor)
+- **Testing**: JUnit 5, Mockito (inline mock maker), AssertJ, Spring Boot test, Testcontainers (e2e)
 
 ## Architecture Layers
 
@@ -19,10 +21,11 @@ A Spring Boot REST API application for booking office spots with user management
 - **Entities**: `User`, `Booking` with value objects (`UserId`, `UserEmail`, `UserName`, `BookingId`, `BookingDateRange`, `BusinessWeek`, `DateRange`)
 - **Services**: `UserManagement`, `BookingManagement`
 - **Repositories (interfaces)**: `UserRepository`, `BookingRepository`
-- **Exceptions**: 
+- **Validation helpers** (`/domain/validation`): `ValidationProcedure`, `ValidatorWrapper`
+- **Exceptions**:
   - `EntityNotFoundException`
   - `IllegalValueException`
-  - Domain exceptions: `UserAlreadyRegisteredException`, `UserIdMismatchException`, `UserIdMissingException`
+  - Domain exceptions: `UserAlreadyRegisteredException`, `EmailAlreadyTakenException`, `UserIdMismatchException`, `UserIdMissingException`
 
 ### Infrastructure Layer (`/infrastructure`)
 
@@ -31,6 +34,7 @@ A Spring Boot REST API application for booking office spots with user management
 - Uses DTO classes for entity-mapper pattern:
   - `UserJpaDto`, `BookingJpaDto` (entity wrappers)
   - `UserRepositoryJpaImpl`, `BookingRepositoryJpaImpl` (repository implementations)
+  - `JpaUserRepository`, `JpaBookingRepository` (Spring Data interfaces)
 
 #### REST (`/infrastructure/rest`)
 - API response entities:
@@ -41,8 +45,8 @@ A Spring Boot REST API application for booking office spots with user management
 - `ErrorResponse` for error responses
 
 ### Controllers (`/controllers`)
-- `OfficeBookingController` - Booking operations
-- `UserController` - User management operations
+- `OfficeBookingController` - Booking operations, mapped under `/office`
+- `UserController` - User management operations, mapped under `/users`
 
 ## Key Features
 - User registration and management
@@ -56,13 +60,86 @@ A Spring Boot REST API application for booking office spots with user management
 ## Run Commands
 ```bash
 ./gradlew bootRun           # Start application
-./gradlew test              # Run tests
-./gradlew clean build       # Build with tests
+./gradlew test              # Run unit and integration tests (JVM only)
+./gradlew e2eTest           # Run end-to-end tests (needs a container runtime)
+./gradlew clean build       # Build with tests; does NOT run e2eTest
+./gradlew bootJar           # Build the runnable jar used by the Docker image
 ```
 
 ## API Endpoints (Swagger UI: http://localhost:8080/swagger-ui.html)
-- User endpoints via `/users`
-- Office booking endpoints via `/office-bookings`
+- Users (`/users`): `POST /users/user`, `PUT /users/user/{userId}`, `GET /users/user/{userId}`,
+  `GET /users/users`, `DELETE /users/user/{userId}`
+- Office bookings (`/office`): `POST /office/booking`, `GET /office/bookings/{businessDay}`
+  (everything booked in the business week that day falls into), `DELETE /office/booking/{bookingId}`
+
+## Testing
+
+### Unit and integration tests (`src/test`)
+- Run in the JVM with `./gradlew test`, need nothing but the JDK.
+- Domain and mapping tests are plain JUnit 5 + Mockito; the inline mock maker is enabled via
+  `src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker`.
+- Controller tests (`*ControllerIT`) use `@SpringBootTest` + `@AutoConfigureMockMvc` with
+  `@MockitoBean` domain services, so they cover the HTTP mapping without a database.
+
+### End-to-end tests (`src/e2eTest`)
+- Live in their own Gradle source set, declared with `sourceSets { e2eTest }` in `build.gradle`.
+- The source set deliberately does **not** depend on the main classes: the tests talk to the
+  running application over HTTP only, so nothing but the published contract is exercised.
+  Request bodies are re-declared locally as records (`UserPayload`, `BookingPayload`).
+- Dependencies are `e2eTestImplementation` only (Testcontainers, JUnit Jupiter, AssertJ,
+  Jackson databind); their versions come from the Spring Boot BOM.
+
+Layout of `src/e2eTest/java/org/denysr/learning/office_booking/e2e/`:
+
+| File | Role |
+| --- | --- |
+| `ApplicationUnderTest` | JUnit extension: starts the app container, injects API clients |
+| `ApiClient` | Marker interface; implementations take the base URL as the only ctor argument |
+| `HttpCalls` | Shared `java.net.http` plumbing and JSON serialisation |
+| `ApiResponse` | Raw `(status, body)` record with `json()`, `userId()`, `bookingId()`, `error()` helpers |
+| `UserApiClient` / `BookingApiClient` | Clients for `/users` and `/office` |
+| `UserApiE2eTest` / `BookingApiE2eTest` | The tests, each `@ExtendWith(ApplicationUnderTest.class)` |
+| `../resources/logback-test.xml` | Quiets Testcontainers and application container output |
+
+How it runs:
+- `ApplicationUnderTest` keeps the container in the JUnit **launcher session store**, so it is
+  started once per test run no matter how many classes ask for it, and stopped when the session ends.
+- Readiness is a `Wait.forHttp("/users/users")` check for a 200, which only answers once the whole
+  context including JPA is up (5 minute startup timeout).
+- The container port is published to a random free host port, so parallel runs do not collide.
+- By default the image is built from the project `Dockerfile` (`ImageFromDockerfile`, tagged
+  `office-booking-e2e:latest`), so a bare `./gradlew e2eTest` works with nothing prepared.
+  Pass `-Pe2eImage=<image>` to test an image built beforehand - that is what CI does.
+  The `e2eTest` task passes `e2e.projectRoot` and, when given, `e2e.image` as system properties.
+- The task sets `outputs.upToDateWhen { false }` (Gradle cannot know whether a container result
+  still holds) and `shouldRunAfter test`.
+
+Test conventions:
+- All tests share one application instance and therefore one database. Nothing may rely on a known
+  database state: user tests register their own user under a unique email, booking tests claim a
+  business week of their own (weeks counted off from Monday 2030-01-07).
+- Adding coverage for another part of the API means writing its client and adding one entry to the
+  `ApplicationUnderTest.CLIENTS` map; the extension needs no other change.
+
+Running e2e tests with Podman (Testcontainers speaks the Docker API):
+```bash
+systemctl --user start podman.socket
+export DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock
+export TESTCONTAINERS_RYUK_DISABLED=true
+./gradlew e2eTest
+```
+
+## Docker
+- Multi-stage `Dockerfile`: `eclipse-temurin:25-jdk` builds the jar with `./gradlew bootJar`
+  (dependencies resolved in their own layer first), `eclipse-temurin:25-jre` runs it.
+- Exposes port 8080; entrypoint `java -jar app.jar`.
+- `docker-compose.yml` is available for running the application locally.
+
+## CI (`.github/workflows`)
+- `build-pr.yml` - on PRs to `master`: JDK 25, `./gradlew build` then `./gradlew test`.
+- `e2e.yml` - on PRs and pushes to `master`: builds the image with Buildx (GitHub Actions layer
+  cache) as `office-booking:e2e`, then runs `./gradlew e2eTest -Pe2eImage=office-booking:e2e`
+  and uploads `build/reports/tests/e2eTest` as an artifact.
 
 ## Project Structure
 ```
@@ -77,6 +154,8 @@ src/main/java/org/denysr/learning/office_booking/
 ├── infrastructure/
 │   ├── jpa/             # JPA repositories and DTOs
 │   └── rest/            # REST DTOs and response entities
+src/test/java/...        # Unit and integration tests (./gradlew test)
+src/e2eTest/java/...     # End-to-end tests over HTTP (./gradlew e2eTest)
 ```
 
 ## Notes


### PR DESCRIPTION
## What

Enriches `claude.md` with the end-to-end test setup, and refreshes the parts of it that had drifted from the code.

### E2E tests

A new `## Testing` section covering both source sets. For the e2e side:

- the separate `e2eTest` source set and why it deliberately does not see the main classes — the tests talk HTTP only, so request bodies are re-declared locally as records
- a file-by-file table of `src/e2eTest/java/.../e2e/`
- how `ApplicationUnderTest` starts one container per JUnit launcher session, the `/users/users` readiness probe, and the random published host port
- image selection: built from the project `Dockerfile` by default, `-Pe2eImage=<image>` for a prebuilt one (what CI uses)
- the `outputs.upToDateWhen { false }` / `shouldRunAfter test` wiring on the `e2eTest` task
- the conventions the tests follow given one shared database: unique emails, a business week of one's own
- the `ApplicationUnderTest.CLIENTS` map as the extension point for covering another part of the API
- the Podman recipe

### Corrections and gaps

- booking endpoints were documented under `/office-bookings`; the controller maps `/office`. Both controllers' endpoints are now listed explicitly.
- added Lombok and the `gradle/libs.versions.toml` version catalog to the tech stack
- added `EmailAlreadyTakenException` and the `domain/validation` helpers
- added `Docker` and `CI` sections (both workflows)
- added `e2eTest` and `bootJar` to the run commands, and noted that `clean build` does not run e2e

## Testing

Documentation only — no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)