### PR TITLE
refactor: split e2e harness into its own package

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -93,13 +93,24 @@ Layout of `src/e2eTest/java/org/denysr/learning/office_booking/e2e/`:
 
 | File | Role |
 | --- | --- |
+| `UserApiE2eTest` / `BookingApiE2eTest` | The tests, each `@ExtendWith(ApplicationUnderTest.class)` |
+| `../resources/logback-test.xml` | Quiets Testcontainers and application container output |
+
+The harness the tests run against lives one level down, in `.../e2e/harness/`, so the package holding
+the tests only ever holds tests:
+
+| File | Role |
+| --- | --- |
 | `ApplicationUnderTest` | JUnit extension: starts the app container, injects API clients |
 | `ApiClient` | Marker interface; implementations take the base URL as the only ctor argument |
 | `HttpCalls` | Shared `java.net.http` plumbing and JSON serialisation |
 | `ApiResponse` | Raw `(status, body)` record with `json()`, `userId()`, `bookingId()`, `error()` helpers |
 | `UserApiClient` / `BookingApiClient` | Clients for `/users` and `/office` |
-| `UserApiE2eTest` / `BookingApiE2eTest` | The tests, each `@ExtendWith(ApplicationUnderTest.class)` |
-| `../resources/logback-test.xml` | Quiets Testcontainers and application container output |
+| `UserPayload` / `BookingPayload` | Request bodies for the user and booking endpoints |
+
+Everything the tests reference (`ApplicationUnderTest`, the API clients, `ApiResponse`, the payload
+records) is `public` because it now lives in a separate package; `ApiClient` and `HttpCalls` stay
+package-private since they are only used inside `harness` itself.
 
 How it runs:
 - `ApplicationUnderTest` keeps the container in the JUnit **launcher session store**, so it is

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/BookingApiE2eTest.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/BookingApiE2eTest.java
@@ -12,6 +12,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import org.denysr.learning.office_booking.e2e.harness.ApiResponse;
+import org.denysr.learning.office_booking.e2e.harness.ApplicationUnderTest;
+import org.denysr.learning.office_booking.e2e.harness.BookingApiClient;
+import org.denysr.learning.office_booking.e2e.harness.BookingPayload;
+import org.denysr.learning.office_booking.e2e.harness.UserApiClient;
+import org.denysr.learning.office_booking.e2e.harness.UserPayload;
+
 /**
  * End-to-end coverage of the basic booking path against the application running in a container.
  * <p>

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/UserApiE2eTest.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/UserApiE2eTest.java
@@ -10,6 +10,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import org.denysr.learning.office_booking.e2e.harness.ApiResponse;
+import org.denysr.learning.office_booking.e2e.harness.ApplicationUnderTest;
+import org.denysr.learning.office_booking.e2e.harness.UserApiClient;
+import org.denysr.learning.office_booking.e2e.harness.UserPayload;
+
 /**
  * End-to-end coverage of the user path against the application running in a container.
  * <p>

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/UserPayload.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/UserPayload.java
@@ -1,9 +1,0 @@
-package org.denysr.learning.office_booking.e2e;
-
-/** Request body of the user endpoints, declared independently of the application classes. */
-record UserPayload(String email, String firstName, String secondName) {
-
-    static UserPayload validUser(String email) {
-        return new UserPayload(email, "John", "Doe");
-    }
-}

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/ApiClient.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/ApiClient.java
@@ -1,4 +1,4 @@
-package org.denysr.learning.office_booking.e2e;
+package org.denysr.learning.office_booking.e2e.harness;
 
 /**
  * Marks a client of one part of the API. Implementations take the base URL of the running

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/ApiResponse.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/ApiResponse.java
@@ -1,4 +1,4 @@
-package org.denysr.learning.office_booking.e2e;
+package org.denysr.learning.office_booking.e2e.harness;
 
 import java.io.UncheckedIOException;
 
@@ -7,10 +7,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /** Raw HTTP response, kept unparsed so that error paths can be asserted as easily as happy ones. */
-record ApiResponse(int status, String body) {
+public record ApiResponse(int status, String body) {
     private static final ObjectMapper JSON = new ObjectMapper();
 
-    JsonNode json() {
+    public JsonNode json() {
         try {
             return JSON.readTree(body);
         } catch (JsonProcessingException e) {
@@ -19,17 +19,17 @@ record ApiResponse(int status, String body) {
     }
 
     /** Id returned by the user create and change endpoints. */
-    int userId() {
+    public int userId() {
         return json().path("userId").asInt();
     }
 
     /** Id returned by the booking create endpoint. */
-    int bookingId() {
+    public int bookingId() {
         return json().path("bookingId").asInt();
     }
 
     /** Message of an {@code ErrorResponse}. */
-    String error() {
+    public String error() {
         return json().path("error").asText();
     }
 

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/ApplicationUnderTest.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/ApplicationUnderTest.java
@@ -1,4 +1,4 @@
-package org.denysr.learning.office_booking.e2e;
+package org.denysr.learning.office_booking.e2e.harness;
 
 import java.nio.file.Path;
 import java.time.Duration;
@@ -32,7 +32,7 @@ import org.testcontainers.utility.DockerImageName;
  * {@code ./gradlew e2eTest} works with nothing prepared up front. Pass {@code -Pe2eImage=<image>}
  * to test an image that was built beforehand - that is what CI does.
  */
-final class ApplicationUnderTest implements BeforeAllCallback, ParameterResolver {
+public final class ApplicationUnderTest implements BeforeAllCallback, ParameterResolver {
     private static final Namespace NAMESPACE = Namespace.create(ApplicationUnderTest.class);
 
     /** The injectable API clients, each built from the base URL of the running application. */

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/BookingApiClient.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/BookingApiClient.java
@@ -1,25 +1,25 @@
-package org.denysr.learning.office_booking.e2e;
+package org.denysr.learning.office_booking.e2e.harness;
 
 import java.time.LocalDate;
 
 /** Client for the {@code /office} API. */
-final class BookingApiClient implements ApiClient {
+public final class BookingApiClient implements ApiClient {
     private final HttpCalls http;
 
-    BookingApiClient(String baseUrl) {
+    public BookingApiClient(String baseUrl) {
         this.http = new HttpCalls(baseUrl);
     }
 
-    ApiResponse createBooking(BookingPayload booking) {
+    public ApiResponse createBooking(BookingPayload booking) {
         return http.send(http.request("/office/booking").POST(HttpCalls.jsonBody(booking)));
     }
 
     /** Bookings of the whole business week that the given day falls into. */
-    ApiResponse getBookingsForWeekOf(LocalDate businessDay) {
+    public ApiResponse getBookingsForWeekOf(LocalDate businessDay) {
         return http.send(http.request("/office/bookings/" + businessDay).GET());
     }
 
-    ApiResponse deleteBooking(int bookingId) {
+    public ApiResponse deleteBooking(int bookingId) {
         return http.send(http.request("/office/booking/" + bookingId).DELETE());
     }
 }

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/BookingPayload.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/BookingPayload.java
@@ -1,4 +1,4 @@
-package org.denysr.learning.office_booking.e2e;
+package org.denysr.learning.office_booking.e2e.harness;
 
 import java.time.LocalDate;
 
@@ -6,9 +6,9 @@ import java.time.LocalDate;
  * Request body of the booking endpoint. Dates are strings so that the tests send the wire format
  * verbatim rather than whatever a date module would produce.
  */
-record BookingPayload(int userId, String startDate, String endDate) {
+public record BookingPayload(int userId, String startDate, String endDate) {
 
-    static BookingPayload of(int userId, LocalDate startDate, LocalDate endDate) {
+    public static BookingPayload of(int userId, LocalDate startDate, LocalDate endDate) {
         return new BookingPayload(userId, startDate.toString(), endDate.toString());
     }
 }

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/HttpCalls.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/HttpCalls.java
@@ -1,4 +1,4 @@
-package org.denysr.learning.office_booking.e2e;
+package org.denysr.learning.office_booking.e2e.harness;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/UserApiClient.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/UserApiClient.java
@@ -1,30 +1,30 @@
-package org.denysr.learning.office_booking.e2e;
+package org.denysr.learning.office_booking.e2e.harness;
 
 /** Client for the {@code /users} API. */
-final class UserApiClient implements ApiClient {
+public final class UserApiClient implements ApiClient {
     private final HttpCalls http;
 
-    UserApiClient(String baseUrl) {
+    public UserApiClient(String baseUrl) {
         this.http = new HttpCalls(baseUrl);
     }
 
-    ApiResponse createUser(UserPayload user) {
+    public ApiResponse createUser(UserPayload user) {
         return http.send(http.request("/users/user").POST(HttpCalls.jsonBody(user)));
     }
 
-    ApiResponse changeUser(int userId, UserPayload user) {
+    public ApiResponse changeUser(int userId, UserPayload user) {
         return http.send(http.request("/users/user/" + userId).PUT(HttpCalls.jsonBody(user)));
     }
 
-    ApiResponse getUser(int userId) {
+    public ApiResponse getUser(int userId) {
         return http.send(http.request("/users/user/" + userId).GET());
     }
 
-    ApiResponse getAllUsers() {
+    public ApiResponse getAllUsers() {
         return http.send(http.request("/users/users").GET());
     }
 
-    ApiResponse deleteUser(int userId) {
+    public ApiResponse deleteUser(int userId) {
         return http.send(http.request("/users/user/" + userId).DELETE());
     }
 }

--- a/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/UserPayload.java
+++ b/src/e2eTest/java/org/denysr/learning/office_booking/e2e/harness/UserPayload.java
@@ -1,0 +1,9 @@
+package org.denysr.learning.office_booking.e2e.harness;
+
+/** Request body of the user endpoints, declared independently of the application classes. */
+public record UserPayload(String email, String firstName, String secondName) {
+
+    public static UserPayload validUser(String email) {
+        return new UserPayload(email, "John", "Doe");
+    }
+}


### PR DESCRIPTION
## Summary
- Move the API clients, `ApplicationUnderTest`, request/response types, and `HttpCalls` from `e2e` into a new `e2e.harness` subpackage, so the `e2e` package holds only the two test classes (`UserApiE2eTest`, `BookingApiE2eTest`).
- Widen visibility to `public` only where the tests now reach across the package boundary (`ApplicationUnderTest`, the two API clients, `ApiResponse` and its accessor methods, the payload records and their factory methods). `ApiClient` and `HttpCalls` stay package-private since they're only used inside `harness` itself.
- Update `claude.md`'s e2e layout table to match the new structure.

## Test plan
- [x] `./gradlew compileE2eTestJava` succeeds
- [ ] `./gradlew e2eTest` (needs a container runtime, not run in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)